### PR TITLE
Allow to cross-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,13 @@ user@/path/to/WebKit$ Tools/jhbuild/jhbuild-wrapper --wpe run /path/to/dyz/launc
     ```
     user@path/to/dyz$ ./launch -b /path/to/WebKit/WebKitBuild/Release/
     ```
+
+
+Cross-Build
+-----------
+
+For cross-building it should suffice with setting the environment variables
+CC pointing to the name of your cross-compiler and PKG_CONFIG_PATH to the
+path where the target sysroot is installed (needs luajit)
+
+make clean && CC=arm-linux-gnueabihf-gcc PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig make

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,6 +5,30 @@ BINDIR ?= $(PREFIX)/bin
 LIBDIR ?= $(PREFIX)/lib
 CC ?= gcc
 
+TARGET_MACHINE := $(shell $(CC) -dumpmachine)
+
+ifneq (,$(findstring aarch64-,$(TARGET_MACHINE)))
+	ARCH := arm64
+else ifneq (,$(findstring arm-,$(TARGET_MACHINE)))
+	ARCH := arm
+else ifneq (,$(findstring mips-,$(TARGET_MACHINE)))
+	ARCH := mips
+else ifneq (,$(findstring x86_64-,$(TARGET_MACHINE)))
+	ARCH := x64
+else ifneq (,$(findstring i686-,$(TARGET_MACHINE)))
+	ARCH := x86
+else ifneq (,$(findstring i586-,$(TARGET_MACHINE)))
+	ARCH := x86
+else ifneq (,$(findstring i486-,$(TARGET_MACHINE)))
+	ARCH := x86
+else ifneq (,$(findstring i386-,$(TARGET_MACHINE)))
+	ARCH := x86
+endif
+
+ifeq ($(strip $(ARCH)),)
+$(error Unsupported target CPU: $(TARGET_MACHINE))
+endif
+
 LUA_SRCS := \
 	entrypoint.lua \
 	main.lua \
@@ -32,7 +56,7 @@ dyz: main.o $(LUA_OBJS)
 	$(CC) -o $@ $^ $(LDFLAGS) -Wl,--no-as-needed -Wl,-E
 
 %_lua.o: %.lua
-	$(LUAJIT) -bg -n $(subst /,.,$*) $< $@
+	$(LUAJIT) -bg -a $(ARCH) -n $(subst /,.,$*) $< $@
 
 install: dyz
 	mkdir -p $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
 * Get the target architecture from the GCC triplet and pass it with
   the name that luajit expects.