### PR TITLE
Enable some run-time setting by default

### DIFF
--- a/src/apps/singleview/main.lua
+++ b/src/apps/singleview/main.lua
@@ -8,7 +8,13 @@ function module.run(args)
     local context = glib.g_main_context_default()
     local loop = glib.g_main_loop_new(context, 0)
 
-    local view = wpe.webkit_web_view_new()
+    local settings = wpe.webkit_settings_new_with_settings(
+                        "allow-file-access-from-file-urls", true,
+                        "allow-universal-access-from-file-urls", true,
+                        "enable-write-console-messages-to-stdout", true,
+                        nil)
+
+    local view = wpe.webkit_web_view_new_with_settings(settings)
 
     local url = "https://www.duckduckgo.com"
     if #args > 0 then

--- a/src/lib/wpewebkit_glibapi.lua
+++ b/src/lib/wpewebkit_glibapi.lua
@@ -4,7 +4,11 @@ local wk = ffi.load("libWPEWebKit.so")
 
 ffi.cdef[[
     typedef struct _WebKitWebView WebKitWebView;
+    typedef struct _WebKitSettings WebKitSettings;
 
+    WebKitSettings* webkit_settings_new_with_settings (const char* first_setting_name, ...);
+
+    WebKitWebView* webkit_web_view_new_with_settings  (WebKitSettings* settings);
     WebKitWebView* webkit_web_view_new ();
     void webkit_web_view_load_uri (WebKitWebView* web_view, const char* uri);
 ]]


### PR DESCRIPTION
This is very useful for testing. It should be enabled by default (IMHO) like WPELauncher does.

This currently enables:

 * allow-file-access-from-file-urls
 * allow-universal-access-from-file-urls
 * enable-write-console-messages-to-stdout


On the future we should implement some command-line switch to disable/enable features