### PR TITLE
Dont try to guess the path of luajit (cross-build fixes)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,6 +3,7 @@
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 LIBDIR ?= $(PREFIX)/lib
+LUAJIT ?= luajit
 CC ?= gcc
 
 TARGET_MACHINE := $(shell $(CC) -dumpmachine)
@@ -45,10 +46,6 @@ LUAJIT_LDLIBS := $(shell pkg-config luajit --libs)
 
 CFLAGS  += $(LUAJIT_CFLAGS)
 LDFLAGS += $(LUAJIT_LDLIBS)
-
-ifeq ($(strip $(LUAJIT)),)
-  LUAJIT := $(shell pkg-config luajit --variable=prefix)/bin/luajit
-endif
 
 all: dyz
 


### PR DESCRIPTION
 * The variable prefix on the luajit pkg-config file has nothing to do with the path where luajit-native is installed on a cross-build environment.

 * So we should simply call luajit expecting the right program to be  on the PATH.

 * Still allow the PATH or name of the luajit program to be overriden at runtime via the environment variable LUAJIT.


This is likely related to the issue I reported some days ago #6 (We where calling the system luajit instead of luajit-native from Yocto)