### PR TITLE
Add automation support to dyz

### DIFF
--- a/src/apps/singleview/main.lua
+++ b/src/apps/singleview/main.lua
@@ -1,31 +1,88 @@
 
 local module = {}
 
+local ffi = require("ffi")
 local glib = require("lib.glib")
 local wpe = require("lib.wpewebkit_glibapi")
+
+ffi.cdef[[
+    typedef void (*WebContextAutomationStartedCallback) (WebKitWebContext*, WebKitAutomationSession*, WebKitWebView*);
+    typedef WebKitWebView* (*AutomationSessionCreateWebViewCallback) (WebKitAutomationSession*, WebKitWebView*);
+    typedef void (*WebViewCloseCallback)(WebKitWebView*, GMainLoop*);
+]]
+
+local function table_contains(table, item)
+    for key, value in pairs(table) do
+        if value == item then
+            return true
+        end
+    end
+    return false
+end
+
+local function g_signal_connect(obj, sig, ftype, f, data, flags)
+    return glib.g_signal_connect_data(obj, sig,
+        ffi.cast("GCallback", ffi.cast(ftype, f)), data, nil, flags or 0)
+end
+
+local function create_web_view_for_automation_cb(session, view)
+    return view
+end
+
+local function automation_started_cb(web_context, session, view)
+    g_signal_connect(session, "create-web-view", "AutomationSessionCreateWebViewCallback", create_web_view_for_automation_cb, view)
+end
+
+local function web_view_close_cb(view, loop)
+    glib.g_main_loop_quit(loop);
+end
 
 function module.run(args)
     local context = glib.g_main_context_default()
     local loop = glib.g_main_loop_new(context, 0)
+
+    local automation_mode = table_contains(args, "--automation")
+    local web_context
+    if automation_mode then
+        web_context = wpe.webkit_web_context_new_ephemeral()
+    else
+        web_context = wpe.webkit_web_context_get_default()
+    end
 
     local settings = wpe.webkit_settings_new_with_settings(
                         "allow-file-access-from-file-urls", true,
                         "allow-universal-access-from-file-urls", true,
                         "enable-write-console-messages-to-stdout", true,
                         nil)
+    local view = glib.g_object_new(wpe.webkit_web_view_get_type(),
+                        "web-context", web_context,
+                        "settings", settings,
+                        "is-controlled-by-automation", automation_mode,
+                        nil)
+    glib.g_object_unref(settings)
+    g_signal_connect(view, "close", "WebViewCloseCallback", web_view_close_cb, loop)
+    if automation_mode then
+        wpe.webkit_web_context_set_automation_allowed(web_context, true)
+        g_signal_connect(web_context, "automation-started", "WebContextAutomationStartedCallback", automation_started_cb, view)
+    end
 
-    local view = wpe.webkit_web_view_new_with_settings(settings)
-
-    local url = "https://www.duckduckgo.com"
-    if #args > 0 then
+    local url
+    if automation_mode then
+        url = "about:blank"
+    elseif #args > 0 then
         url = args[1]
+    else
+        url = "https://www.duckduckgo.com"
     end
 
     wpe.webkit_web_view_load_uri(view, url)
 
     glib.g_main_loop_run(loop)
 
-    glib.gobject_unref(view)
+    glib.g_object_unref(view)
+    if automation_mode then
+        glib.g_object_unref(web_context)
+    end
     glib.g_main_loop_unref(loop)
 end
 

--- a/src/lib/glib.lua
+++ b/src/lib/glib.lua
@@ -1,21 +1,33 @@
 local ffi = require("ffi")
 
-local lib = ffi.load("libglib-2.0.so")
+local lib = ffi.load("libgobject-2.0.so")
 
 ffi.cdef[[
     typedef struct _GMainContext GMainContext;
     typedef struct _GMainLoop GMainLoop;
+    typedef struct _GClosure GClosure;
+
+    typedef void (*GCallback)(void);
+    typedef void (*GClosureNotify)(void *data, GClosure *closure);
+    typedef int (*GSourceFunc)(void *data);
+
+    typedef enum { G_CONNECT_AFTER = 1, G_CONNECT_SWAPPED = 2 } GConnectFlags;
 
     typedef int gboolean;
     typedef void* gpointer;
+    typedef size_t GType;
 
     GMainContext* g_main_context_default (void);
 
     GMainLoop* g_main_loop_new (GMainContext *context, gboolean is_running);
+    void g_main_loop_quit (GMainLoop *loop);
     void g_main_loop_run (GMainLoop *loop);
     void g_main_loop_unref (GMainLoop *loop);
 
+    gpointer g_object_new (GType object_type, const char *first_property_name, ...);
     void g_object_unref (gpointer object);
+
+    unsigned long g_signal_connect_data (gpointer instance, const char *detailed_signal, GCallback c_handler, gpointer data, GClosureNotify destroy_data, GConnectFlags connect_flags);
 ]]
 
 return lib

--- a/src/lib/wpewebkit_glibapi.lua
+++ b/src/lib/wpewebkit_glibapi.lua
@@ -3,13 +3,21 @@ local ffi = require("ffi")
 local wk = ffi.load("libWPEWebKit.so")
 
 ffi.cdef[[
+    typedef struct _WebKitAutomationSession WebKitAutomationSession;
+    typedef struct _WebKitWebContext WebKitWebContext;
     typedef struct _WebKitWebView WebKitWebView;
     typedef struct _WebKitSettings WebKitSettings;
 
     WebKitSettings* webkit_settings_new_with_settings (const char* first_setting_name, ...);
 
-    WebKitWebView* webkit_web_view_new_with_settings  (WebKitSettings* settings);
+    WebKitWebContext* webkit_web_context_new_ephemeral ();
+    WebKitWebContext* webkit_web_context_get_default ();
+    void webkit_web_context_set_automation_allowed (WebKitWebContext* context, gboolean allowed);
+
+    GType webkit_web_view_get_type ();
+    WebKitWebView* webkit_web_view_new_with_context  (WebKitWebContext* context);
     WebKitWebView* webkit_web_view_new ();
+    void webkit_web_view_set_settings (WebKitWebView* web_view, WebKitSettings* settings);
     void webkit_web_view_load_uri (WebKitWebView* web_view, const char* uri);
 ]]
 


### PR DESCRIPTION
When --automation is passed, dyz will work in automation mode. This
means that an ephemeral session will be used and automation will be
enabled in the context.